### PR TITLE
Avoid unsafe reference to activity

### DIFF
--- a/app/src/main/java/com/zackhsi/kiva/fragments/LoanListViewFragment.java
+++ b/app/src/main/java/com/zackhsi/kiva/fragments/LoanListViewFragment.java
@@ -6,6 +6,7 @@ import android.os.Bundle;
 import android.support.v4.app.ActivityOptionsCompat;
 import android.support.v4.app.Fragment;
 import android.support.v7.widget.LinearLayoutManager;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -167,13 +168,8 @@ public class LoanListViewFragment extends Fragment {
             }
 
             @Override
-            public void onFailure(int statusCode, Header[] headers, String responseString, Throwable throwable) {
-                Toast.makeText(getActivity(), "Problem loading loans", Toast.LENGTH_SHORT).show();
-            }
-
-            @Override
             public void onFailure(int statusCode, Header[] headers, Throwable throwable, JSONObject errorResponse) {
-                Toast.makeText(getActivity(), "Problem loading loans", Toast.LENGTH_SHORT).show();
+                Log.e("LOANS", "Problem loading loans", throwable);
                 super.onFailure(statusCode, headers, throwable, errorResponse);
             }
         });


### PR DESCRIPTION
If the API call fails after the fragment has detached from its activity,
we get an error:

```
04-10 01:26:09.513    7454-7454/com.zackhsi.kiva E/AndroidRuntime﹕ FATAL EXCEPTION: main
    Process: com.zackhsi.kiva, PID: 7454
    java.lang.NullPointerException: Attempt to invoke virtual method 'android.content.res.Resources android.content.Context.getResources()' on a null object reference
            at android.widget.Toast.<init>(Toast.java:101)
            at android.widget.Toast.makeText(Toast.java:250)
            at com.zackhsi.kiva.fragments.LoanListViewFragment$2.onFailure(LoanListViewFragment.java:176)
            at com.loopj.android.http.JsonHttpResponseHandler.onFailure(JsonHttpResponseHandler.java:200)
            at com.loopj.android.http.AsyncHttpResponseHandler.handleMessage(AsyncHttpResponseHandler.java:319)
            at com.loopj.android.http.AsyncHttpResponseHandler$ResponderHandler.handleMessage(AsyncHttpResponseHandler.java:138)
            at android.os.Handler.dispatchMessage(Handler.java:102)
            at android.os.Looper.loop(Looper.java:135)
            at android.app.ActivityThread.main(ActivityThread.java:5221)
            at java.lang.reflect.Method.invoke(Native Method)
            at java.lang.reflect.Method.invoke(Method.java:372)
            at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:899)
            at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:694)
```
